### PR TITLE
VEVOS Simulation V1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.variantsync.vevos</groupId>
 	<!-- Adjust the generateVariant name -->
     <artifactId>Simulation</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.1</version>
 
     <properties>
         <!-- Adjust your java version here -->

--- a/src/main/java/org/variantsync/vevos/simulation/io/kernelhaven/VariabilityModelLoader.java
+++ b/src/main/java/org/variantsync/vevos/simulation/io/kernelhaven/VariabilityModelLoader.java
@@ -30,10 +30,7 @@ public class VariabilityModelLoader implements ResourceLoader<IFeatureModel> {
                 return FeatureModelUtils.FromVariabilityModel(cache.readFixed(p.toFile()));
             } else {
                 List<String> variables = Files.readAllLines(p).stream().map(String::trim).collect(Collectors.toList());
-                final IFeatureModel featureModel = DefaultFeatureModelFactory.getInstance().create();
-                IFeature root = DefaultFeatureModelFactory.getInstance().createFeature(featureModel, "ROOT");
-                FeatureUtils.setRoot(featureModel, root);
-                return FeatureModelUtils.FillFeatureModel(featureModel, variables);
+                return FeatureModelUtils.FromOptionalFeatures(variables);
             }
         });
     }

--- a/src/main/java/org/variantsync/vevos/simulation/util/fide/FormulaUtils.java
+++ b/src/main/java/org/variantsync/vevos/simulation/util/fide/FormulaUtils.java
@@ -6,6 +6,8 @@ import org.variantsync.vevos.simulation.util.fide.bugfix.FixTrueFalse;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 public class FormulaUtils {
     public static Node negate(final Node node) {
@@ -60,7 +62,41 @@ public class FormulaUtils {
         } while (!redundantChildren.isEmpty());
     }
 
-    public static String toString(final Node formula, final String[] symbols) {
+    /**
+     * Replaces all nodes within the given formula's tree that match the given predicate.
+     * Matching nodes (i.e., nodes for which the predicate who returns true) will be replaced by the value returned
+     * by the replacement function, invoked on the matching node.
+     * @param root The root of the formula in which occurences of formulas should be replaced. The object remains unaltered.
+     * @param who A replacement is made whenever this predicate evaluates to true on a given node.
+     * @param replacement Whenever a node should be replaced, this function is invoked with that node as argument.
+     *                    The node will be replaced with the node returned.
+     * @return A new formula in which all nodes matching the given predicate are replaced.
+     */
+    public static Node replaceAll(final Node root, final Predicate<Node> who, final Function<Node, Node> replacement) {
+        return replaceAllInplace(root.clone(), who, replacement);
+    }
+
+    /**
+     * Inplace variant of the {@link #replaceAll(Node, Predicate, Function)} function.
+     * This means the given formula (root parameter) will be altered.
+     */
+    public static Node replaceAllInplace(final Node root, final Predicate<Node> who, final Function<Node, Node> replacement) {
+        if (who.test(root)) {
+            return replacement.apply(root);
+        } else {
+            final Node[] children = root.getChildren();
+            for (int i = 0; i < children.length; ++i) {
+                children[i] = replaceAllInplace(children[i], who, replacement);
+            }
+            root.setChildren(children);
+            return root;
+        }
+    }
+
+    public static String toString(Node formula, final String[] symbols) {
+        formula = replaceAll(formula, FixTrueFalse::isTrue, n -> FixTrueFalse.TrueAs1);
+        formula = replaceAllInplace(formula, FixTrueFalse::isFalse, n -> FixTrueFalse.FalseAs0);
+
         final NodeWriter writer = new NodeWriter(formula);
         writer.setNotation(NodeWriter.Notation.INFIX);
         writer.setEnquoteWhitespace(false);

--- a/src/main/java/org/variantsync/vevos/simulation/util/fide/FormulaUtils.java
+++ b/src/main/java/org/variantsync/vevos/simulation/util/fide/FormulaUtils.java
@@ -73,6 +73,10 @@ public class FormulaUtils {
      * @return A new formula in which all nodes matching the given predicate are replaced.
      */
     public static Node replaceAll(final Node root, final Predicate<Node> who, final Function<Node, Node> replacement) {
+        if (root == null) {
+            return null;
+        }
+
         return replaceAllInplace(root.clone(), who, replacement);
     }
 
@@ -81,14 +85,20 @@ public class FormulaUtils {
      * This means the given formula (root parameter) will be altered.
      */
     public static Node replaceAllInplace(final Node root, final Predicate<Node> who, final Function<Node, Node> replacement) {
+        if (root == null) {
+            return null;
+        }
+
         if (who.test(root)) {
             return replacement.apply(root);
         } else {
             final Node[] children = root.getChildren();
-            for (int i = 0; i < children.length; ++i) {
-                children[i] = replaceAllInplace(children[i], who, replacement);
+            if (children != null) {
+                for (int i = 0; i < children.length; ++i) {
+                    children[i] = replaceAllInplace(children[i], who, replacement);
+                }
+                root.setChildren(children);
             }
-            root.setChildren(children);
             return root;
         }
     }

--- a/src/main/java/org/variantsync/vevos/simulation/util/fide/bugfix/FixTrueFalse.java
+++ b/src/main/java/org/variantsync/vevos/simulation/util/fide/bugfix/FixTrueFalse.java
@@ -17,15 +17,22 @@ import java.util.function.Predicate;
  * as well as a conversion method for parsing certain feature names to true and false, respectively.
  */
 public class FixTrueFalse {
-    /// Names of variables that we want to interpret as atomic values true or false, respectively.
-    public final static List<String> TrueNames = Arrays.asList("true", "1");
-    public final static List<String> FalseNames = Arrays.asList("false", "0");
-
     /*
     Constant literals representing the true and false value
      */
     public final static Literal True = new org.prop4j.True();
     public final static Literal False = new org.prop4j.False();
+
+    /*
+    Constant literals representing the true and false values only for serialization.
+    True and False are represented by the numeric values 0 and 1.
+     */
+    public final static Literal TrueAs1 = new Literal("1");
+    public final static Literal FalseAs0 = new Literal("0");
+
+    /// Names of variables that we want to interpret as atomic values true or false, respectively.
+    public final static List<String> TrueNames  = Arrays.asList("true",  (String) TrueAs1.var);
+    public final static List<String> FalseNames = Arrays.asList("false", (String) FalseAs0.var);
 
     /**
      * @return True iff the given formula is a true literal.
@@ -47,14 +54,14 @@ public class FixTrueFalse {
      * @return True iff the given name represents the atomic value true w.r.t. the constant TrueNames.
      */
     public static boolean isTrueLiteral(final Literal l) {
-        return TrueNames.stream().anyMatch(t -> t.equals(l.var.toString().toLowerCase()));
+        return TrueNames.stream().anyMatch(t -> t.equalsIgnoreCase(l.var.toString()));
     }
 
     /**
      * @return True iff the given name represents the atomic value false w.r.t. the constant FalseNames.
      */
     public static boolean isFalseLiteral(final Literal l) {
-        return FalseNames.stream().anyMatch(f -> f.equals(l.var.toString().toLowerCase()));
+        return FalseNames.stream().anyMatch(f -> f.equalsIgnoreCase(l.var.toString()));
     }
 
     private static Node[] filterMatches(final Node[] nodes, Predicate<Node> filter) {

--- a/src/main/java/org/variantsync/vevos/simulation/variability/pc/variantlines/VariantAnnotation.java
+++ b/src/main/java/org/variantsync/vevos/simulation/variability/pc/variantlines/VariantAnnotation.java
@@ -2,6 +2,7 @@ package org.variantsync.vevos.simulation.variability.pc.variantlines;
 
 import org.prop4j.Node;
 import org.prop4j.NodeWriter;
+import org.variantsync.vevos.simulation.util.fide.FormulaUtils;
 import org.variantsync.vevos.simulation.variability.pc.options.VariantGenerationOptions;
 
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ public record VariantAnnotation(
         final List<String> result = new ArrayList<>();
 
         if (projectionOptions.withMacros()) {
-            result.add("#if " + condition.toString(NodeWriter.javaSymbols));
+            result.add("#if " + FormulaUtils.toString(condition, NodeWriter.javaSymbols));
         }
 
         for (final VariantLineChunk child : lines) {


### PR DESCRIPTION
This release contains three bug fixes. 

The first fix (147b9246389097ab3e36949079152e35e4fb7b94) was done by coincidence and originally supposed to be only a refactoring. However, as it turned out, the old implementation of loading a feature model from a list of variables was incorrect. This might be due to a change in the FeatureIDE library. Feature models are now initialized correctly.

The second fix addresses the generation of preprocessor macros in variants. Previously, _true_ and _false_ literals were directly converted into preprocessor annotations (e.g., `#if true`. This caused incorrect behavior, because the preprocessor interpreted them as variables instead of literals. The literals are now converted to `0` and `1`. 

The third fix introduces additional null checks to prevent exceptions. 