### PR TITLE
VEVOS Simulation v1.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.variantsync.vevos</groupId>
 	<!-- Adjust the generateVariant name -->
     <artifactId>simulation</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
 
     <properties>
         <!-- Adjust your java version here -->

--- a/src/main/java/org/variantsync/vevos/simulation/io/TextIO.java
+++ b/src/main/java/org/variantsync/vevos/simulation/io/TextIO.java
@@ -19,8 +19,7 @@ import java.util.stream.Stream;
 // TODO: Implement readLinesAs(Path p, Function<> f) with which one can load a file into a desired format
 
 public class TextIO {
-    public final static String LINEBREAK = "\r\n";
-    public final static String LINEBREAK_REGEX = "\\r?\\n";
+    public final static String LINEBREAK = System.lineSeparator();
 
     public static String[] readLinesAsArray(final File file) throws IOException {
         final LinkedList<String> lines = new LinkedList<>();

--- a/src/main/java/org/variantsync/vevos/simulation/io/kernelhaven/VariabilityModelLoader.java
+++ b/src/main/java/org/variantsync/vevos/simulation/io/kernelhaven/VariabilityModelLoader.java
@@ -1,9 +1,6 @@
 package org.variantsync.vevos.simulation.io.kernelhaven;
 
-import de.ovgu.featureide.fm.core.base.FeatureUtils;
-import de.ovgu.featureide.fm.core.base.IFeature;
 import de.ovgu.featureide.fm.core.base.IFeatureModel;
-import de.ovgu.featureide.fm.core.base.impl.DefaultFeatureModelFactory;
 import net.ssehub.kernel_haven.variability_model.JsonVariabilityModelCache;
 import org.variantsync.functjonal.Result;
 import org.variantsync.vevos.simulation.io.ResourceLoader;
@@ -25,7 +22,7 @@ public class VariabilityModelLoader implements ResourceLoader<IFeatureModel> {
     @Override
     public Result<IFeatureModel, ? extends Exception> load(Path p) {
         return Result.Try(() -> {
-            if (p.endsWith(".json")) {
+            if (p.toString().endsWith(".json")) {
                 JsonVariabilityModelCache cache = new JsonVariabilityModelCache(p.getParent().toFile());
                 return FeatureModelUtils.FromVariabilityModel(cache.readFixed(p.toFile()));
             } else {


### PR DESCRIPTION
This release contains two fixes. The first fixes a bug that caused feature model specified as JSON files to be loaded as a simple list of features. This bug occurred due to an invalid usage of Path's endsWith. The second fixes the line endings of generated variants.